### PR TITLE
Task-58585: Fix validated document from dpl cnnot be opened in preview mode

### DIFF
--- a/dlp-services/src/main/java/org/exoplatform/dlp/connector/FileDlpConnector.java
+++ b/dlp-services/src/main/java/org/exoplatform/dlp/connector/FileDlpConnector.java
@@ -426,8 +426,12 @@ public class FileDlpConnector extends DlpServiceConnector {
     Session restoreSession = securityHomeNode.getSession();
     Node securityNode = (Node) restoreSession.getItem(securityNodePath);
     String restorePath = securityNode.getProperty(RESTORE_PATH).getString();
-
     restoreSession.getWorkspace().move(securityNodePath, restorePath);
+    // we set the EXO_LAST_MODIFIER to set the updater who validate the document in dlp administration.
+    if(securityNode.hasProperty(NodetypeConstant.EXO_LAST_MODIFIER)){
+      restoreSession.getNodeByUUID(securityNode.getUUID())
+                    .setProperty(NodetypeConstant.EXO_LAST_MODIFIER ,securityNode.getProperty(NodetypeConstant.EXO_LAST_MODIFIER).getString());
+    }
     removeRestorePathInfo(restoreSession, restorePath);
     securityHomeNode.save();
     restoreSession.save();

--- a/dlp-services/src/test/java/org/exoplatform/dlp/connector/FileDlpConnectorTest.java
+++ b/dlp-services/src/test/java/org/exoplatform/dlp/connector/FileDlpConnectorTest.java
@@ -144,6 +144,8 @@ public class FileDlpConnectorTest {
     when(property.getString()).thenReturn("restorePath");
     when(item.getPath()).thenReturn("path");
     when(session.getItem("path")).thenReturn(item);
+    when(session.getNodeByUUID(item.getUUID())).thenReturn(item);
+    when(item.getProperty(NodetypeConstant.EXO_LAST_MODIFIER)).thenReturn(property);
     when(session.getWorkspace()).thenReturn(workspace);
     when(session.getItem("restorePath")).thenReturn(item);
 


### PR DESCRIPTION
ISSUE : when dlp admin validate document and user wants to open it on preview mode , the document not opened and a console error displayed 'cannot read properties of null (reading full name)' the problem is when admin dlp validate a document the document restored on document app with the updater properties null .
FIX : set property EXO_LAST_MODIFIER to restored node and that fix the problem