### PR TITLE
feat: Delete usage of Jcabi to use AspectJ Maven Plugin - MEED-7544 - Meeds-io/meeds#2417

### DIFF
--- a/dlp-services/pom.xml
+++ b/dlp-services/pom.xml
@@ -83,10 +83,6 @@
           </swaggerConfig>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This change will delete the usage of Jcabi Maven plugin which is incompatible with newer AspectJ versions and use AspectJ Maven plugin instead