### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/dlp-services/src/main/resources/db/changelog/dlp-rdbms.db.changelog-1.0.0.xml
+++ b/dlp-services/src/main/resources/db/changelog/dlp-rdbms.db.changelog-1.0.0.xml
@@ -99,13 +99,14 @@
   </changeSet>
   
   <changeSet author="exo-dlp" id="1.0.0-8">
+    <validCheckSum>9:29316e6ea1f11ab12eb204c8a4bc817c</validCheckSum>
     <modifyDataType columnName="KEYWORDS"
-                    newDataType="NVARCHAR(500)"
+                    newDataType="VARCHAR(500)"
                     tableName="DLP_POSITIVE_ITEMS"/>
     <rollback>
       <!-- This rollback is need because in unit test we will revert all changes after each test case-->
       <modifyDataType columnName="KEYWORDS"
-                      newDataType="NVARCHAR(50)"
+                      newDataType="VARCHAR(50)"
                       tableName="DLP_POSITIVE_ITEMS"/>
     </rollback>
   </changeSet>


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR.
This commit adapt liquibase changes in order to apply this change.